### PR TITLE
Remove unnescessary ALL_ONES mask

### DIFF
--- a/shatranj.py
+++ b/shatranj.py
@@ -384,7 +384,7 @@ class Position:
             if (wtm): 
                 from_square = to_square>>7 
             else:
-                from_square = to_square<<9 & ALL_ONES
+                from_square = to_square<<9
             mask = self.pinned(from_square,wtm)
             if (mask & to_square):
                 if (rank[to_square] == 8 or rank[to_square] == 1):


### PR DESCRIPTION
A very minor change, only cosmetic: Remove an extra careful
`& ALL_ONES` for right pawn capture generation. Only pawns
on the relevant files will be considered anyway.

After this the right_captures code will be symmetrical with
the left_captures code.
