### PR TITLE
Allow blocking a check with promotion

### DIFF
--- a/shatranj.py
+++ b/shatranj.py
@@ -1084,15 +1084,17 @@ class Position:
                     #print "FOUND SINGLE"
                     blocking_pawn = empty_square & forward_pawns
                     if (wtm):
-                        mask = self.pinned(blocking_pawn>>8,wtm)
-                        if (mask & empty_square):
-                            move_list.append(Move(blocking_pawn >> 8,
-                                                 empty_square,"","",""))
+                        from_square = blocking_pawn>>8
                     else:
-                        mask = self.pinned(blocking_pawn<<8,wtm)
-                        if (mask & empty_square):
-                            move_list.append(Move(blocking_pawn << 8,
-                                                 empty_square,"","",""))
+                        from_square = blocking_pawn<<8
+                    mask = self.pinned(from_square,wtm)
+                    if mask & empty_square:
+                        if rank[empty_square] == 1 or rank[empty_square] == 8:
+                            move_list.append(Move(from_square,empty_square,
+                                                 "promotion","","Q"))
+                        else:
+                            move_list.append(Move(from_square,empty_square,
+                                                 "","",""))
                 elif (empty_square & double_forward_pawns):
                     # double moves for pawns must make sure that nothing
                     # is blocking their move to the empty square


### PR DESCRIPTION
A blocking move (type 3 check evasion) might be a promotion.

Sample position (white to move):

```
. . . r . . . K
. . . . . . P .
. .   . . . . .
. . . . . . . .
. . . . . . . .
. .   . . . . .
. . . . . . . .
. . . k . . . .
```

Legal moves are are `Kh7` and `g8=`.
